### PR TITLE
sharing-variables-between-stylus-and-js

### DIFF
--- a/example/src/styles/index.styl
+++ b/example/src/styles/index.styl
@@ -3,11 +3,12 @@
 @import './scroll.styl'
 @import './text.styl'
 
-// 目前在styl里直接处理变量好像不如scss方便，暂时直接用导入的方式获得变量
-// 可能会用到的链接🔗 https://medium.com/qbits/sharing-variables-between-stylus-and-react-324bf3b43f33
+// 在styl里可以直接用styl的变量，但是在js里暂时无法获得。sass好像可以通过 :export的方式暴露变量
+// 如果用stylus实现——大致原理：通过json文件，实现变量共享
+// sass参考链接🔗 https://www.bluematador.com/blog/how-to-share-variables-between-js-and-sass
+// stylus可能用到链接🔗 https://medium.com/qbits/sharing-variables-between-stylus-and-react-324bf3b43f33
 
 // 目前设计出的图里，还没有涉及到其他色系，但是先考虑到更改系统配色。
 
 .test-color-primary
-  // color $primaryColor
-  background $primaryColor
+  background $primary-color-background

--- a/example/src/styles/variable.json
+++ b/example/src/styles/variable.json
@@ -1,0 +1,9 @@
+{
+  "primary":{
+    "color":{
+      "background": "blue",
+      "text":"green"
+    }
+  },
+  "testother":"yellow"
+}

--- a/example/src/styles/variable.styl
+++ b/example/src/styles/variable.styl
@@ -2,4 +2,36 @@
   样式变量——以后可能有用
 */
 
-$primaryColor = #ff0000
+json('./variable.json', false, "$")
+/*
+  json(地址，哈希(应该是哈希，但应该对应的是一个settingOption)，前缀)
+  原理&目标：
+    1、在styl里可以直接用styl的变量，但是在js里暂时无法获得。sass好像可以通过 :export的方式暴露变量
+    2、如果用stylus实现——大致原理：通过json文件，实现变量共享
+    3、在vue的stylus中使用变量——暂未实现⭐暂时没有解决方案
+    4、在js中使用：import导入的方式
+      4-1：需要更改tsconfig.json 🔗https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html
+      4-2：{
+            "compilerOptions": {
+              "module": "commonjs",
+              "resolveJsonModule": true,
+              "esModuleInterop": true
+            }
+          }
+  注：
+    1、引入的json文件不能打注释，打了注释stylus解析会失败，如果加了然后抱错，那么就得重新跑一次项目🙄
+    2、因为是引入的json文件，所以如果对json文件做了修改，保存不会立马有效果，需要重新加载一次(可以在这个页面做个修改，然后重新加载)😅
+  解析方式为：
+    1、{}会转化为 - ，有时间看看 写个递归处理成和json一样用 - 的形式（不过不一定是必要的，毕竟可以链式操作）
+  参考链接：
+    1、json https://github.com/stylus/stylus/issues/2441
+    2、sass https://www.bluematador.com/blog/how-to-share-variables-between-js-and-sass
+    3、stylus https://medium.com/qbits/sharing-variables-between-stylus-and-react-324bf3b43f33
+*/
+
+
+.test-vars
+  background $primary-color-text
+  color $testother
+  &:hover
+    color $primary-color-background

--- a/example/src/views/Teacher/classManage/index.vue
+++ b/example/src/views/Teacher/classManage/index.vue
@@ -1,20 +1,32 @@
 <template lang="pug">
 .main
   .test.flex.flex-row
-    .test1.font-size-16.pointer 2
-    .test1.test-color-primary 1
-    .test1 3
+    .test1.font-size-16.pointer 1
+    .test1.test-color-primary 2
+    .test1.test-vars 3
+    .test1.test-self-style 4
 </template>
 <script lang="ts">
 import { defineAsyncComponent, defineComponent } from 'vue';
+import StylusJson from '@/styles/variable.json';
 
 export default defineComponent({
   components: {
     theHeader: defineAsyncComponent(() => import('@/components/Teacher/header.vue')),
   },
+  setup() {
+    console.log(StylusJson, 'sssssssss');
+    return {};
+  },
 });
 </script>
 <style lang="stylus" scoped>
+// @import '@/styles/variable.styl'
+// 引入抱错，暂时先不考虑。如果想用的话，直接在stylus文件里定义类，然后直接在html里使用。再不济就单独写stylus控制
+
 .main
   height 120vh
+  .test
+    .test-self-style
+      background $testother
 </style>

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -7,6 +7,7 @@
     "importHelpers": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,


### PR DESCRIPTION
将stylus的变量共享到js里
如果以后设计更改主题配色的话，可能会有用(通过json文件作为中间值)